### PR TITLE
Enable ENV for setting light bulb

### DIFF
--- a/lib/rspec_hue.rb
+++ b/lib/rspec_hue.rb
@@ -43,7 +43,10 @@ class RspecHue
 		@failure_count > 0
 	end
 	def setup_philips_hue_controller
-		options = { bulb_id_to_use: RSpec.configuration.rspec_hue_light_id, output: output }
+		options = {
+			bulb_id_to_use: ENV["RSPEC_HUE_LIGHT_ID"] || RSpec.configuration.rspec_hue_light_id,
+			output: output
+		}
 		failed_color = RSpec.configuration.rspec_hue_failed_color
 		passed_color = RSpec.configuration.rspec_hue_passed_color
 		hue_ip = RSpec.configuration.rspec_hue_ip


### PR DESCRIPTION
Just enabling the config to set the light id from a ENV variable for easier setup of new project as no Rspec config is necessary
