### PR TITLE
Rspec3 compatibility

### DIFF
--- a/lib/philips_hue_controller.rb
+++ b/lib/philips_hue_controller.rb
@@ -2,6 +2,7 @@ require 'huey'
 require 'null_bulb'
 
 class PhilipsHueController
+
 	def initialize options = {}
 		@configuration = default_options.merge options
 		if configuration.has_key? :bulb_id_to_use
@@ -10,18 +11,23 @@ class PhilipsHueController
 			@bulb = passed_bulb_or_null_bulb
 		end
 	end
+
 	def failed
-		bulb.update(configuration[:failed_color])		
+		bulb.update(configuration[:failed_color])
 	end
+
 	def passed
-		bulb.update(configuration[:passed_color])		
+		bulb.update(configuration[:passed_color])
 	end
+
 	private
+
 	def configuration
 		@configuration
 	end
+
 	def default_options
-		{ 
+		{
 			hue_ip: nil,
 			ssdp_ip: '239.255.255.250',
 			ssdp_port: 1900,
@@ -33,25 +39,30 @@ class PhilipsHueController
 			passed_color: { bri: 57, ct: 500, xy: [ 0.408, 0.517 ] }
 		}
 	end
+
 	def output
 		configuration[:output]
 	end
+
 	def bulb
 		@bulb
 	end
+
 	def passed_bulb_or_null_bulb
 		configuration.fetch(:bulb, NullBulb.new )
 	end
+
 	def init_bulb
 		@bulb = Huey::Bulb.find(configuration[:bulb_id_to_use]) if configuration.has_key? :bulb_id_to_use
 		@bulb = passed_bulb_or_null_bulb if @bulb.nil? #Huey return nil if not found
 		@bulb.on = true
 		@bulb.transitiontime = configuration[:bulb_transition_time]
 	end
+
 	def init_philips_hue
 	 	# Must do this, othwerwise Huey starts pushing out debug messages
 	 	Huey::Config.logger = ::Logger.new(nil)
-		begin		
+		begin
 			Huey.configure do |config|
 				if configuration[:hue_ip].nil?
 					config.ssdp = true
@@ -79,7 +90,7 @@ class PhilipsHueController
 		rescue Huey::Errors::PressLinkButton
 			if STDIN.tty?
 				output.puts "RspecHue: Not authorized, press linkbutton on Philips Hue, then press enter here to continue, or q and enter to skip."
-				input = gets.strip 
+				input = gets.strip
 				unless input.downcase == "q"
 					init_philips_hue
 				else

--- a/lib/rspec_hue.rb
+++ b/lib/rspec_hue.rb
@@ -16,7 +16,7 @@ class RspecHue
 		:example_failed,
     :dump_summary
 
-	attr_reader :output, :bulb_controller
+	attr_reader :output, :failure_count, :bulb_controller
 
 	class << self
 		def configure_rspec_for_settings

--- a/lib/rspec_hue.rb
+++ b/lib/rspec_hue.rb
@@ -1,47 +1,74 @@
 require 'rspec'
 require 'philips_hue_controller'
 
-class RspecHue 
-	def initialize output, additional_args = {}
-		@output = output || StringIO.new
-		@additional_args = additional_args
-		@failure_count = 0
-	end
-	#called by rspec
-	def dump_summary duration, example_count, failure_count, pending_count
-		@bulb_controller = @additional_args.fetch(:controller) { setup_philips_hue_controller }
-		@failure_count = failure_count
-	end
-	# Catch everything else rspec throws at us, and swallow it.
-	def method_missing m, *args, &block; end
+class RspecHue
 
-	def self.configure_rspec_for_settings
-		RSpec.configure do |c|
-			c.add_setting :rspec_hue_light_id
-			c.add_setting :rspec_hue_ip
-			c.add_setting :rspec_hue_failed_color
-			c.add_setting :rspec_hue_passed_color
-			c.add_setting :rspec_hue_api_user
+	# ::RSpec::Core::Formatters.register self,
+ #    :example_passed,
+ #    :example_pending,
+ #    :example_failed,
+ #    :example_group_started,
+ #    :example_group_finished,
+ #    :dump_summary,
+ #    :seed
+
+	::RSpec::Core::Formatters.register self,
+		:example_failed,
+    :dump_summary
+
+	attr_reader :output, :bulb_controller
+
+	class << self
+		def configure_rspec_for_settings
+			RSpec.configure do |c|
+				c.add_setting :rspec_hue_light_id
+				c.add_setting :rspec_hue_ip
+				c.add_setting :rspec_hue_failed_color
+				c.add_setting :rspec_hue_passed_color
+				c.add_setting :rspec_hue_api_user
+			end
 		end
 	end
 
-	# called by rspec when finished
-	def close()
+	def initialize(output, additional_args = {})
+		@output = output || StringIO.new
+		@additional_args = additional_args
+		@failure_count = 0
+
+		@bulb_controller = @additional_args.fetch(:controller) { setup_philips_hue_controller }
+	end
+
+	def example_passed(notification)
+  end
+
+  def example_pending(notification)
+  end
+
+  def example_failed(notification)
+    @failure_count += 1
+  end
+
+	def dump_summary(summary)
 		init_bulb_controller
-		if failed 
-			bulb_controller.failed 
-		else 
+
+		if failed?
+			bulb_controller.failed
+		else
 			bulb_controller.passed
 		end
 	end
 
+
 	private
+
 	def init_bulb_controller
 		@bulb_controller = @additional_args.fetch(:controller) { setup_philips_hue_controller }
 	end
-	def failed
+
+	def failed?
 		@failure_count > 0
 	end
+
 	def setup_philips_hue_controller
 		options = { bulb_id_to_use: RSpec.configuration.rspec_hue_light_id, output: output }
 		failed_color = RSpec.configuration.rspec_hue_failed_color
@@ -54,12 +81,7 @@ class RspecHue
 		options[:api_user] = api_user unless api_user.nil?
 		PhilipsHueController.new options
 	end
-	def output
-		@output
-	end
-	def bulb_controller
-		@bulb_controller
-	end
-end	
+end
+
 # Must call to add setting-possibilty to RSpec
 RspecHue.configure_rspec_for_settings

--- a/spec/rspec_hue_spec.rb
+++ b/spec/rspec_hue_spec.rb
@@ -7,18 +7,23 @@ describe RspecHue do
 				config.send (setting.to_s + "=").to_sym, RSpec.configuration.send(setting)
 			end
 		end
+
 		it "should be able to set :rspec_hue_light_id" do
 			expect { set_rspec_setting :rspec_hue_light_id }.to_not raise_exception
 		end
+
 		it "should be able to set :rspec_hue_ip" do
 			expect { set_rspec_setting :rspec_hue_ip }.to_not raise_exception
 		end
+
 		it "should be able to set :rspec_hue_failed_color" do
 			expect { set_rspec_setting :rspec_hue_failed_color }.to_not raise_exception
 		end
+
 		it "should be able to set :rspec_hue_passed_color" do
 			expect { set_rspec_setting :rspec_hue_passed_color }.to_not raise_exception
 		end
+
 		it "should be able to set :rspec_hue_api_user" do
 			expect { set_rspec_setting :rspec_hue_api_user }.to_not raise_exception
 		end
@@ -31,9 +36,11 @@ describe RspecHue do
 			c
 		end
 		let(:formatter) { RspecHue.new StringIO.new, controller: controller }
+
 		it "should respond dump_summary" do
 			expect { formatter.dump_summary 123,2,1,1 }.to_not raise_exception
 		end
+
 		it "should not raise error if calling close() before dump_summary" do
 			expect { formatter.close() }.to_not raise_exception
 		end

--- a/spec/rspec_hue_spec.rb
+++ b/spec/rspec_hue_spec.rb
@@ -28,6 +28,7 @@ describe RspecHue do
 			expect { set_rspec_setting :rspec_hue_api_user }.to_not raise_exception
 		end
 	end
+
 	context "when corresponding to the formatter interface" do
 		let(:controller) do
 			c = double("controller")
@@ -38,11 +39,11 @@ describe RspecHue do
 		let(:formatter) { RspecHue.new StringIO.new, controller: controller }
 
 		it "should respond dump_summary" do
-			expect { formatter.dump_summary 123,2,1,1 }.to_not raise_exception
+			expect { formatter.dump_summary "foo" }.to_not raise_exception
 		end
 
-		it "should not raise error if calling close() before dump_summary" do
-			expect { formatter.close() }.to_not raise_exception
+		it "should increment #failed_count by 1" do
+			expect { formatter.example_failed(nil) }.to change { formatter.failure_count }.by(1)
 		end
 	end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'rspec_hue'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.filter_run_excluding :integration


### PR DESCRIPTION
Make the formatter compatible to the new Rspec3 style of writing formatters. Not backwards compatible.
